### PR TITLE
Add check for multiple initialization

### DIFF
--- a/screenlog.js
+++ b/screenlog.js
@@ -39,6 +39,10 @@
 	}
 
 	function init(options){
+		if(isInitialized){
+			return;
+		}
+
 		isInitialized = true;
 		options = options || {};
 		logEl = createPanel(options);


### PR DESCRIPTION
Check if screenlog is being initialized multiple times. 
Currently, multiple calls to `screenLog.init();` creates new elements(superimposing over each other).
This PR basically ignores the `screenLog.init()` if it's called once already.
