### PR TITLE
Replaces deprecated licenses field with new license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,7 @@
   "author": {
     "name": "Kushagra Gour"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/chinchang/screenlog.js/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/chinchang/screenlog.js/issues"
   },


### PR DESCRIPTION
This fixes the following warning (thrown when doing `npm install`)

``` bash
npm WARN screenlog@0.1.3 No license field.
```

Refer to https://docs.npmjs.com/files/package.json#license
